### PR TITLE
[Feat] 아이돌 목록, 후원 목록, 차트, 투표, 후원 api 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "fandom-k",
       "version": "0.0.0",
       "dependencies": {
+        "axios": "^1.7.5",
         "eslint-config-prettier": "^9.1.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -1523,6 +1524,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -1537,6 +1544,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.5.tgz",
+      "integrity": "sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1678,6 +1696,18 @@
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1843,6 +1873,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/doctrine": {
@@ -2460,6 +2499,26 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -2468,6 +2527,20 @@
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fsevents": {
@@ -3296,6 +3369,27 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3604,6 +3698,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "axios": "^1.7.5",
     "eslint-config-prettier": "^9.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+// api instance
+export const instance = axios.create({
+    baseURL: 'https://fandom-k-api.vercel.app/9-4',
+    timeout: 3000,
+});

--- a/src/api/charts.js
+++ b/src/api/charts.js
@@ -1,0 +1,14 @@
+import { instance } from './api';
+
+// 아이돌 차트 받아오기
+export const getCharts = async ({ gender = 'female', cursor = null, pageSize = 10 }) => {
+    const response = await instance
+        .get(`charts/{gender}`, { params: { gender, cursor, pageSize } })
+        .then((res) => {
+            return res.data;
+        })
+        .catch((error) => {
+            return error;
+        });
+    return response;
+};

--- a/src/api/donations.js
+++ b/src/api/donations.js
@@ -1,0 +1,29 @@
+import { instance } from './api';
+
+// 후원 목록 받아오기
+export const getDonations = async ({ cursor = null, pageSize = 10 }) => {
+    const response = await instance
+        .get(`/donations`, { params: { cursor, pageSize } })
+        .then((res) => {
+            return res.data;
+        })
+        .catch((error) => {
+            return error;
+        });
+    return response;
+};
+
+// 모집 중인 조공에 대해 크레딧을 사용해 후원하기
+export const putContribute = async (id, amount) => {
+    const response = await instance
+        .put(`/donations/${id}/contribute`, {
+            amount,
+        })
+        .then((response) => {
+            return response.data;
+        })
+        .catch((error) => {
+            return error;
+        });
+    return response;
+};

--- a/src/api/idols.js
+++ b/src/api/idols.js
@@ -1,0 +1,14 @@
+import { instance } from './api';
+
+// 아이돌 목록 받아오기
+export const getIdols = async ({ cursor = null, pageSize = 10 }) => {
+    const response = await instance
+        .get(`/Idols`, { params: { cursor, pageSize } })
+        .then((res) => {
+            return res.data;
+        })
+        .catch((error) => {
+            return error;
+        });
+    return response;
+};

--- a/src/api/votes.js
+++ b/src/api/votes.js
@@ -1,0 +1,14 @@
+import { instance } from './api';
+
+// 투표 생성
+export const postVotes = (idolId) => {
+    const response = instance
+        .post(`/votes`, { idolId })
+        .then((res) => {
+            return res.data;
+        })
+        .catch((error) => {
+            return error;
+        });
+    return response;
+};


### PR DESCRIPTION
프로젝트 요구사항에 있는 api 함수들을 추가했습니다.
### api 목록
- `getIdols` : 아이돌 목록 불러오기
    - `cursor` : 커서
    - `pageSize` : 페이지 사이즈 ( 기본값 : 10 )
 <br>

- `getCharts` : 아이돌 차트 불러오기
    - `gender` : 성별 ( 기본값 : female )
    - `cursor` : 커서
    - `pageSize` : 페이지 사이즈 ( 기본값 : 10 )
 <br>

- `postVotes` : 아이돌 투표하기
    - `idolId` : 투표할 아이돌 id
 <br>

- `getDonations` : 후원 목록 불러오기
    - `cursor` : 커서
    - `pageSize` : 페이지 사이즈 ( 기본값 : 10 )
 <br>

- `putContribute` : 모집 중인 조공에 대해 크레딧을 사용해 후원하기
    - `id` : 후원할 아이돌 id
    - `amount` : 후원할 크레딧 양