### PR TITLE
[Fix] 모달 수정사항 반영 

### DIFF
--- a/src/components/list/CreditStatus.jsx
+++ b/src/components/list/CreditStatus.jsx
@@ -4,8 +4,8 @@ import creditImg from '../../assets/icon/credit.svg';
 import CreditCharge from '../modals/CreditCharge';
 
 const CreditStatus = () => {
-    const [modalClose, setModalClose] = useState(false);
-
+    const [modalClose, setModalClose] = useState(true);
+    
     const handleChargeModal = () => {
         setModalClose((prev) => !prev);
     };
@@ -22,7 +22,7 @@ const CreditStatus = () => {
                 </MyCreditAmount>
             </MyCreditBox>
             <ChargeBtn onClick={handleChargeModal}>충전하기</ChargeBtn>
-            {modalClose && <CreditCharge setModalClose={setModalClose} />}
+            {!modalClose && <CreditCharge setModalClose={setModalClose} />}
         </Container>
     );
 };

--- a/src/components/list/CreditStatus.jsx
+++ b/src/components/list/CreditStatus.jsx
@@ -1,87 +1,85 @@
-import { useState } from "react";
-import styled from "styled-components";
+import { useState } from 'react';
+import styled from 'styled-components';
 import creditImg from '../../assets/icon/credit.svg';
-import CreditCharge from "../modals/CreditCharge";
+import CreditCharge from '../modals/CreditCharge';
 
 const CreditStatus = () => {
-  const [modalClose, setModalClose] = useState(false);
-  
-  const handleChargeModal = () => {
-    setModalClose((prev) => !prev);
-  }
+    const [modalClose, setModalClose] = useState(false);
 
-  const currentCredit = parseInt(localStorage.getItem('credit'), 10).toLocaleString('ko-KR');
+    const handleChargeModal = () => {
+        setModalClose((prev) => !prev);
+    };
 
-  return (
-    <Container>
-      <MyCreditBox>
-        <h2>내 크레딧</h2>
-        <MyCreditAmount>
-          <img src={creditImg} alt="크레딧" />
-          {currentCredit}
-        </MyCreditAmount>
-      </MyCreditBox>
-      <ChargeBtn onClick={handleChargeModal} >충전하기</ChargeBtn>
-      {modalClose && <CreditCharge setModalClose={setModalClose} />}
-    </Container>
-  )
-}
+    const currentCredit = parseInt(localStorage.getItem('credit'), 10) || 0;
+
+    return (
+        <Container>
+            <MyCreditBox>
+                <h2>내 크레딧</h2>
+                <MyCreditAmount>
+                    <img src={creditImg} alt="크레딧" />
+                    {currentCredit !== 0 ? currentCredit.toLocaleString('ko-KR') : 0}
+                </MyCreditAmount>
+            </MyCreditBox>
+            <ChargeBtn onClick={handleChargeModal}>충전하기</ChargeBtn>
+            {modalClose && <CreditCharge setModalClose={setModalClose} />}
+        </Container>
+    );
+};
 
 export default CreditStatus;
 
 const Container = styled.div`
-  width: 1280px;
-  margin: auto;
-  margin-top: 130px;
-  padding: 30px 80px;
-  border: 1px solid rgba(241, 238, 249, 0.8);
-  border-radius: 8px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+    max-width: 1200px;
+    width: 100%;
+    margin: auto;
+    margin-top: 130px;
+    padding: 30px 80px;
+    border: 1px solid rgba(241, 238, 249, 0.8);
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
 
-  @media (min-width: 768px) and (max-width: 1279px) {
-    width: 696px;
-    padding: 30px 50px;
-  }
+    @media (min-width: 768px) and (max-width: 1279px) {
+        padding: 30px 50px;
+    }
 
-  @media (min-width: 375px) and (max-width: 767px) {
-    width: 327px;
-    padding: 30px;
-  }
+    @media (min-width: 375px) and (max-width: 767px) {
+        padding: 30px;
+    }
 `;
 
 const MyCreditBox = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 15px;
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
 
-  h2 {
-    color: rgba(255, 255, 255, 0.6);
-    font-size: 16px;
-    line-height: 19.09px;
-  }
+    h2 {
+        color: rgba(255, 255, 255, 0.6);
+        font-size: 16px;
+        line-height: 19.09px;
+    }
 `;
 
 const MyCreditAmount = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  color: rgba(255, 255, 255, 0.87);
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    color: rgba(255, 255, 255, 0.87);
 
-  img {
-    width: 16px;
-    height: 16px;
-  }
+    img {
+        width: 16px;
+        height: 16px;
+    }
 `;
 
 const ChargeBtn = styled.button`
-  background: none;
-  border: none;
-  color: var(--brand100);
-  font-size: 16px;
-  font-weight: 700;
-  letter-spacing: 1.5px;
-  line-height: 26px;
+    background: none;
+    border: none;
+    color: var(--brand100);
+    font-size: 16px;
+    font-weight: 700;
+    letter-spacing: 1.5px;
+    line-height: 26px;
 `;

--- a/src/components/modals/AlarmModal.jsx
+++ b/src/components/modals/AlarmModal.jsx
@@ -5,32 +5,38 @@ import Button from '../Button';
 import closeBtn from '../../assets/image/btn_delete_24px.svg';
 import creditImg from '../../assets/icon/credit.svg';
 
-// 크레딧 부족 시 모달
-const CreditNotEnough = ({ setModalClose }) => {
+// 크레딧 부족 시, 투표 완료했을 때 띄울 공용 모달
+const AlarmModal = ({ setAlertModalClose, title = 'credit' }) => {
     // 모달창 닫는 함수
     const handleModalClose = () => {
-        setModalClose((prev) => !prev);
+        setAlertModalClose((prev) => !prev);
     };
 
     return (
         <ModalContainer>
             <ContentsBox>
                 <CloseBtn onClick={handleModalClose}>
-                    <img src={closeBtn} alt='닫기' />
+                    <img src={closeBtn} alt="닫기" />
                 </CloseBtn>
                 <Contents>
-                    <img src={creditImg} alt='크레딧' />
-                    <p>
-                        앗! 투표하기 위한 <span>크레딧</span>이 부족해요
-                    </p>
+                    <img src={creditImg} alt="크레딧" />
+                    {title === 'credit' ? (
+                        <p>
+                            앗! 투표하기 위한 <span>크레딧</span>이 부족해요
+                        </p>
+                    ) : (
+                        <p>투표가 완료되었습니다.</p>
+                    )}
                 </Contents>
-                <Button onClick={handleModalClose} width='100%'>확인</Button>
+                <Button onClick={handleModalClose} width="100%">
+                    확인
+                </Button>
             </ContentsBox>
         </ModalContainer>
     );
 };
 
-export default CreditNotEnough;
+export default AlarmModal;
 
 const ContentsBox = styled(ContentsBoxStyle)`
     width: 343px;

--- a/src/components/modals/CreditCharge.jsx
+++ b/src/components/modals/CreditCharge.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import ModalContainer from './ModalContainer';
 import styled from 'styled-components';
 import Button from '../Button';
-import { ContentsBoxStyle, NumberInput, TitleStyle } from '../../styles/Modal';
+import { ContentsBoxStyle, DisabledBtn, NumberInput, TitleStyle } from '../../styles/Modal';
 import closeBtn from '../../assets/image/btn_delete_24px.svg';
 import creditImg from '../../assets/icon/credit.svg';
 
@@ -145,13 +145,7 @@ const ChargeBtn = styled(Button)`
     margin-top: 10px;
 
     &:disabled {
-        cursor: default;
-        background: none;
-        background-color: var(--gray200);
-
-        &:hover {
-            opacity: 1;
-        }
+        ${DisabledBtn}
     }
 `;
 

--- a/src/components/modals/CreditCharge.jsx
+++ b/src/components/modals/CreditCharge.jsx
@@ -13,7 +13,7 @@ const CreditCharge = ({ setModalClose }) => {
     const [chargeAmount, setChargeAmount] = useState(0);
     const [customCharge, setCustomCharge] = useState('');
     const [error, setError] = useState(false);
-    
+
     // 모달창 닫는 함수
     const handleModalClose = () => {
         setModalClose((prev) => !prev);

--- a/src/components/modals/ModalContainer.jsx
+++ b/src/components/modals/ModalContainer.jsx
@@ -1,36 +1,54 @@
-import styled from "styled-components";
+import { useState } from 'react';
+import { createPortal } from 'react-dom';
+import styled from 'styled-components';
 
 const ModalContainer = ({ children }) => {
-  return (
-    <Container>
-      <Modal>{children}</Modal>
-    </Container>
-  )
-}
+    const [modalClose, setModalClose] = useState(false);
+    
+    const handleModalClose = () => {
+        setModalClose(true);
+    };
+    
+    const handleModalClick = (e) => {
+        if (e.target === e.currentTarget) {
+          handleModalClose();
+        }
+    };
+
+    return createPortal(
+        <>
+            {!modalClose && (
+                <Container onClick={handleModalClick}>
+                    <Modal onClick={(e) => e.stopPropagation()}>{children}</Modal>
+                </Container>
+            )}
+        </>,
+        document.body,
+    );
+};
 
 export default ModalContainer;
 
 const Container = styled.div`
-  width: 100%;
-  min-height: 100%;
-  background-color: rgba(0, 0, 0, 0.8);
-  position: fixed;
-  top: 0;
-  left: 0;
-  z-index: 30;
+    width: 100%;
+    min-height: 100%;
+    background-color: rgba(0, 0, 0, 0.8);
+    position: fixed;
+    top: 0;
+    left: 0;
 `;
 
 const Modal = styled.div`
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  margin: auto;
-  background-color: #181D26;
-  border-radius: 8px;
-  overflow: hidden;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    margin: auto;
+    background-color: #181d26;
+    border-radius: 8px;
+    overflow: hidden;
 `;

--- a/src/components/modals/SupportModal.jsx
+++ b/src/components/modals/SupportModal.jsx
@@ -4,12 +4,12 @@ import styled from 'styled-components';
 import axios from 'axios';
 import ModalContainer from './ModalContainer';
 import Button from '../Button';
-import { ContentsBoxStyle, NumberInput, TitleStyle } from '../../styles/Modal';
+import { ContentsBoxStyle, DisabledBtn, NumberInput, TitleStyle } from '../../styles/Modal';
 import closeBtn from '../../assets/image/btn_delete_24px.svg';
 import creditImg from '../../assets/icon/credit.svg';
 
 // 후원하기 모달창 (list 페이지에서 donations 자료를 넘겨주어야 합니다.)
-const SupportModal = ({ idolId, idolImgSrc, title, subTitle, setModalClose }) => {
+const SupportModal = ({ item, setModalClose }) => {
     const [userDonation, setUserDonation] = useState('');
     const [error, setError] = useState(false);
     const [isLoading, setLoading] = useState(false);
@@ -44,11 +44,12 @@ const SupportModal = ({ idolId, idolImgSrc, title, subTitle, setModalClose }) =>
 
         try {
             setLoading(true);
-            const response = await putContribute(idolId, userDonation);
+            const response = await putContribute(item.id, userDonation);
 
             if (response) {
                 localStorage.setItem('credit', currentCredit - userDonation);
                 setUserDonation('');
+                setModalClose((prev) => !prev);
             }
         } catch (error) {
             if (axios.isAxiosError(error)) {
@@ -69,23 +70,23 @@ const SupportModal = ({ idolId, idolImgSrc, title, subTitle, setModalClose }) =>
                     </button>
                 </TitleStyle>
                 <IdolBox>
-                    <IdolImg src={idolImgSrc} alt="아이돌 이미지" />
+                    <IdolImg src={item.idol.profilePicture} alt="아이돌 이미지" />
                     <DonationTitleBox>
-                        <h3>{title}</h3>
-                        <p>{subTitle}</p>
+                        <h3>{item.subtitle}</h3>
+                        <p>{item.title}</p>
                     </DonationTitleBox>
                 </IdolBox>
                 <DonationForm onSubmit={handleSubmit}>
                     <InputContainer>
                         <InputBox>
-                            <input
+                            <Input
                                 type="number"
                                 name="donation"
                                 value={userDonation}
                                 onChange={handleUserDonation}
                                 placeholder="크레딧 입력"
                             />
-                            <Input src={creditImg} alt="크레딧" />
+                            <img src={creditImg} alt="크레딧" />
                         </InputBox>
                         {error && <p>갖고 있는 크레딧보다 더 많이 후원할 수 없어요</p>}
                     </InputContainer>
@@ -174,13 +175,7 @@ const Input = styled(NumberInput)`
 
 const DonationBtn = styled(Button)`
     &:disabled {
-        cursor: default;
-        background: none;
-        background-color: var(--gray200);
-
-        &:hover {
-            opacity: 1;
-        }
+        ${DisabledBtn}
     }
 `;
 

--- a/src/components/modals/VoteModal.jsx
+++ b/src/components/modals/VoteModal.jsx
@@ -5,11 +5,10 @@ import Button from '../Button';
 import AlarmModal from './AlarmModal';
 import { postVotes } from '../../api/votes';
 import { ContentsBoxStyle, DisabledBtn, TitleStyle } from '../../styles/Modal';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import closeBtn from '../../assets/image/btn_delete_24px.svg';
 import mobileArrow from '../../assets/icon/icj_arrow_left.svg';
 import check from '../../assets/icon/ic_check.svg';
-import { getIdols } from '../../api/idols';
 
 // 투표하기 모달 (setModalClose 파라미터는 부모 컴포넌트로부터 받은 함수로, 투표하기 모달을 닫는 용도입니다.)
 const VoteModal = ({ idolList = [], title = 'female', setModalClose }) => {
@@ -17,10 +16,9 @@ const VoteModal = ({ idolList = [], title = 'female', setModalClose }) => {
     const [creditAlert, setCreditAlert] = useState(false);
     const [alertModalClose, setAlertModalClose] = useState(true);
     const [isVote, setVote] = useState(false);
-    const [idols, setIdols] = useState([]);
 
     // 투표수가 많은 순으로 정렬, 투표수가 같으면 id순으로 설정해서 순위가 뒤집어지지 않도록 했습니다.
-    const sortIdol = idols?.sort((a, b) => {
+    const sortIdol = idolList?.sort((a, b) => {
         if (b.totalVotes !== a.totalVotes) {
             return b.totalVotes - a.totalVotes;
         } else {
@@ -41,22 +39,6 @@ const VoteModal = ({ idolList = [], title = 'female', setModalClose }) => {
 
         setVoteIdol(value);
     };
-
-    useEffect(() => {
-        const getIdolsList = async () => {
-            try {
-                const response = await getIdols({ cursor: null, pageSize: 10 });
-
-                if (response) {
-                    setIdols(response.list);
-                }
-            } catch (error) {
-                console.error('오류', error);
-            }
-        };
-
-        getIdolsList();
-    }, []);
 
     // 투표하기 버튼 누르면 실행되는 함수
     const handleVote = async (e) => {

--- a/src/components/modals/VoteModal.jsx
+++ b/src/components/modals/VoteModal.jsx
@@ -84,7 +84,7 @@ const VoteModal = ({ idolList = [], title = 'female', setModalClose }) => {
                 </Title>
                 <VoteForm onSubmit={handleVote}>
                     {sortIdol?.length > 0 ? (
-                        sortIdol.map((idol) => (
+                        sortIdol.map((idol, i) => (
                             <FormWrapper key={idol.id}>
                                 <IdolVoteInfo>
                                     <ImgBox>
@@ -100,7 +100,7 @@ const VoteModal = ({ idolList = [], title = 'female', setModalClose }) => {
                                         />
                                         <CheckBackground selected={Number(voteIdol) === idol.id} />
                                     </ImgBox>
-                                    <IdolNumber>{idol.id}</IdolNumber>
+                                    <IdolNumber>{i + 1}</IdolNumber>
                                     <CurrentVoteBox>
                                         <h3>
                                             {idol.group} {idol.name}
@@ -134,6 +134,7 @@ export default VoteModal;
 
 const ContentsBox = styled(ContentsBoxStyle)`
     width: 525px;
+    max-height: 693px;
 
     @media (min-width: 375px) and (max-width: 767px) {
         width: 100vh;
@@ -181,10 +182,13 @@ const VoteForm = styled.form`
     flex-direction: column;
     gap: 8px;
     width: 477px;
+    overflow: auto;
+    padding: 8px 5px;
     margin: auto;
     margin-top: 0;
     @media (min-width: 375px) and (max-width: 767px) {
         width: 327px;
+        padding-bottom: 60px;
     }
 `;
 
@@ -280,6 +284,9 @@ const VoteBtnBox = styled.div`
     gap: 10px;
 
     @media (min-width: 375px) and (max-width: 767px) {
+        position: fixed;
+        bottom: 20px;
+        left: 0;
         background-color: rgba(2, 0, 14, 0.8);
     }
 `;

--- a/src/pages/list/ListPage.jsx
+++ b/src/pages/list/ListPage.jsx
@@ -4,7 +4,6 @@ import ThisMonthChart from './components/ThisMonthChart';
 import Header from '../../components/Header';
 import DonationList from './components/DonationList';
 import styled from 'styled-components';
-import styled from 'styled-components';
 
 const ListPage = () => {
     return (

--- a/src/pages/list/ListPage.jsx
+++ b/src/pages/list/ListPage.jsx
@@ -1,4 +1,3 @@
-
 import CreditStatus from '../../components/list/CreditStatus';
 import ThisMonthChart from './components/ThisMonthChart';
 import Header from '../../components/Header';

--- a/src/pages/list/ListPage.jsx
+++ b/src/pages/list/ListPage.jsx
@@ -1,13 +1,23 @@
 import CreditStatus from '../../components/list/CreditStatus';
 import Header from '../../components/Header';
+import styled from 'styled-components';
 
 const ListPage = () => {
     return (
-        <>
+        <Container>
             <Header />
             <CreditStatus />
-        </>
+        </Container>
     );
 };
 
 export default ListPage;
+
+const Container = styled.div`
+    padding: 0 24px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 50px;
+`;

--- a/src/styles/Modal.jsx
+++ b/src/styles/Modal.jsx
@@ -1,6 +1,6 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
-// 모달 공용 (width를 지정해서 사용해주세요.)
+// 모달 공용 (ContentsBoxStyle 스타일은 width를 지정해서 사용해주세요.)
 export const ContentsBoxStyle = styled.div`
     display: flex;
     flex-direction: column;
@@ -9,6 +9,7 @@ export const ContentsBoxStyle = styled.div`
     box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.25);
 `;
 
+// 모달마다 쓰는 상단 제목과 닫기 버튼이 있는 div 스타일입니다.
 export const TitleStyle = styled.div`
     display: flex;
     align-items: center;
@@ -29,10 +30,22 @@ export const TitleStyle = styled.div`
     }
 `;
 
+// Number 타입의 input 사용 시 오른쪽에 뜨는 숫자 클릭버튼 없애주는 스타일입니다.
 export const NumberInput = styled.input`
     &::-webkit-inner-spin-button,
     &::-webkit-outer-spin-button {
         -webkit-appearance: none;
         margin: 0;
+    }
+`;
+
+// 버튼이 disabled 상태일 때 스타일입니다.
+export const DisabledBtn = css`
+    cursor: default;
+    background: none;
+    background-color: var(--gray200);
+
+    &:hover {
+        opacity: 1;
     }
 `;


### PR DESCRIPTION
## 모달 컴포넌트에서 다음 수정사항을 반영했습니다.

- 크레딧 부족 시 뜨는 CreditNotEnough 컴포넌트를 AlarmModal로 이름변경 후 투표완료 시 뜨는 알람모달로도 재사용가능하게 개선했습니다.
- SupportModal 컴포넌트에 input에 적용되어야 하는 스타일이 img에 적용되서 input의 기본스타일이 노출되었는데, 스타일을 재지정하여 수정했습니다.
- VoteModal 컴포넌트에서 아이돌 이미지가 눌려서 표출되었는데, object-fit 속성을 적용하여 수정했습니다.
  - 데이터가 많아졌을 때 기존 높이를 유지하고 스크롤이 생기도록 수정했습니다. (08-29)
  - 모바일 버전에서 하단 메뉴에 일부 데이터가 가려져서 해당 사항을 수정했습니다. (08-29)
  - 아이돌 차트에서 index로 아이돌 번호를 매기고 있어서, 통일성을 위해 투표하기 모달에서도 인덱스로 나오도록 했습니다. (08-29)
- 뒷배경 클릭 시 모달창 닫는 기능이 추가되었습니다. (08-29)
  - 현재 이 기능으로 닫으면 다시 똑같은 모달을 열 때 두번 클릭해야 하는 버그가 있어서 수정중입니다.
- 모달 컴포넌트들을 z-index를 이용해서 표출하던 것을 portal 사용으로 body 가장 앞쪽에 나오도록 수정했습니다. (08-29)

## List 페이지의 '내 크레딧' 박스 컴포넌트에서 다음 수정사항을 반영했습니다.

- max-width 속성을 1200px로 추가하고, width를 100%로 수정하여 부모 컴포넌트로부터 가운데 정렬되는 속성을 상속받으면서 반응형이 부드럽게 적용되도록 수정했습니다.